### PR TITLE
Fix set seed function for newer versions of Minecraft

### DIFF
--- a/data/nnmath/functions/rand/seed.mcfunction
+++ b/data/nnmath/functions/rand/seed.mcfunction
@@ -1,5 +1,5 @@
 ##by NOPEname
 
 summon minecraft:area_effect_cloud ~ ~ ~ {Tags:["uuid"]}
-execute store result score tmp_lcg nnmath_rand run data get entity @e[tag=uuid,limit=1] UUIDMost[0]
+execute store result score tmp_lcg nnmath_rand run data get entity @e[tag=uuid,limit=1] UUID[0]
 kill @e[tag=uuid]


### PR DESCRIPTION
The UUID format changed to use an int array containing 4 32bit integers, rather than the 2 64bit integers UUIDMost and UUIDLeast

If everything else still works, you might want to update the pack format in pack.mcmeta to 6 as well.